### PR TITLE
Remove whitespace from Postgres query result

### DIFF
--- a/mkdep.sh
+++ b/mkdep.sh
@@ -57,8 +57,9 @@ for i in *.sql ; do
 	  mysql -h $DBHOST -N -u $DBUSER $ROLAPDB)
 	  ;;
 	postgresql)
-	  T=$(echo "SELECT MAX(creation_date) FROM t_create_history  where schema_name = '$ROLAPDB' AND object_identity = '$ROLAPDB.$base'" |
-	  psql -h $DBHOST -U $DBUSER -t -q $MAINDB)
+	  T=$(echo "SELECT MAX(creation_date) FROM t_create_history where schema_name = '$ROLAPDB' AND object_identity = '$ROLAPDB.$base' |
+	  psql -h $DBHOST -U $DBUSER -t -q $MAINDB |
+          sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
 	  ;;
       esac
       if [ -n "$T" ] ; then


### PR DESCRIPTION
Postgres returns a non-zero length string as a result even if the query result
is empty, as it prepends all results with a space. This causes the `-n` check to
fail and consequently the code writes dependency files for tables that have
not been generated yet.